### PR TITLE
added new removeUser method to vaultManager safely handle user deletion

### DIFF
--- a/security/src/main/java/net/e6tech/elements/security/vault/VaultManager.java
+++ b/security/src/main/java/net/e6tech/elements/security/vault/VaultManager.java
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package net.e6tech.elements.security.vault;
 
+import jdk.internal.joptsimple.internal.Strings;
 import net.e6tech.elements.common.logging.Logger;
 import net.e6tech.elements.common.util.SystemException;
 import net.e6tech.elements.security.AsymmetricCipher;
@@ -1042,6 +1043,38 @@ public class VaultManager {
         if (!userLocalOpened)
             throw NOT_OPEN_EXCEPTION;
         return userLocalStore.getVault(USER_VAULT).getSecret(alias, version);
+    }
+
+    public void removeUser(DualEntry dualEntry, String alias) throws GeneralSecurityException {
+        if (!userLocalOpened) {
+            throw NOT_OPEN_EXCEPTION;
+        }
+
+        if (dualEntry == null) {
+            throw new GeneralSecurityException("DualEntry is required.");
+        }
+
+        checkAccess(dualEntry);
+
+        Secret user = getUser(alias, null);
+        if (user == null) {
+            throw new GeneralSecurityException(String.format("User does not exist: %s", alias));
+        }
+
+        String user1 = dualEntry.getUser1() != null ? dualEntry.getUser1().getUser() : null;
+        String user2 = dualEntry.getUser2() != null ? dualEntry.getUser2().getUser() : null;
+
+        if (alias.equalsIgnoreCase(user1) || alias.equalsIgnoreCase(user2)) {
+            throw new GeneralSecurityException(
+                    String.format("Cannot remove a currently authenticated guardian user: %s", alias));
+        }
+
+        try {
+            removeUser(alias, null);
+        } catch (Exception exception) {
+            throw new GeneralSecurityException(
+                    String.format("Failed to remove user: %s", alias), exception);
+        }
     }
 
     private void removeUser(String alias, String version) throws GeneralSecurityException {

--- a/security/src/main/java/net/e6tech/elements/security/vault/VaultManager.java
+++ b/security/src/main/java/net/e6tech/elements/security/vault/VaultManager.java
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package net.e6tech.elements.security.vault;
 
-import jdk.internal.joptsimple.internal.Strings;
 import net.e6tech.elements.common.logging.Logger;
 import net.e6tech.elements.common.util.SystemException;
 import net.e6tech.elements.security.AsymmetricCipher;

--- a/security/src/main/java/net/e6tech/elements/security/vault/VaultManager.java
+++ b/security/src/main/java/net/e6tech/elements/security/vault/VaultManager.java
@@ -1046,10 +1046,6 @@ public class VaultManager {
     }
 
     public void removeUser(DualEntry dualEntry, String alias) throws GeneralSecurityException {
-        if (!userLocalOpened) {
-            throw NOT_OPEN_EXCEPTION;
-        }
-
         if (dualEntry == null) {
             throw new GeneralSecurityException("DualEntry is required.");
         }

--- a/security/src/test/java/net/e6tech/elements/security/vault/VaultManagerTest.java
+++ b/security/src/test/java/net/e6tech/elements/security/vault/VaultManagerTest.java
@@ -12,12 +12,14 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -203,6 +205,111 @@ public class VaultManagerTest {
         manager.changePassphrase(dualEntry);
         ClearText m2 = manager.getKey(Constants.MASTER_KEY_ALIAS, null);
         assertTrue(Arrays.equals(m1.getBytes(), m2.getBytes()));
+    }
+
+    @Test
+    void removeUser_userDoesNotExist_throws() {
+        GeneralSecurityException exception = assertThrows(GeneralSecurityException.class,
+                () -> manager.removeUser(dualEntry, "nonexistentuser"));
+        assertTrue(exception.getMessage().contains("User does not exist: nonexistentuser"));
+    }
+
+    @Test
+    void removeUser_attemptToRemoveUser1_throws() {
+        GeneralSecurityException exception = assertThrows(GeneralSecurityException.class,
+                () -> manager.removeUser(dualEntry, "user1"));
+        assertTrue(exception.getMessage().contains("Cannot remove a currently authenticated guardian user: user1"));
+    }
+
+    @Test
+    void removeUser_attemptToRemoveUser2_throws() {
+        GeneralSecurityException exception = assertThrows(GeneralSecurityException.class,
+                () -> manager.removeUser(dualEntry, "user2"));
+        assertTrue(exception.getMessage().contains("Cannot remove a currently authenticated guardian user: user2"));
+    }
+
+    @Test
+    void removeUser_successfullyRemovesUser() throws Exception {
+        Credential newUser = new Credential("user3", "password3".toCharArray());
+        manager.addUser(newUser, dualEntry.getUser1());
+
+        Set<String> usersBefore = manager.listUsers();
+        assertTrue(usersBefore.contains("user3"));
+        assertEquals(3, usersBefore.size());
+
+        manager.removeUser(dualEntry, "user3");
+
+        Set<String> usersAfter = manager.listUsers();
+        assertFalse(usersAfter.contains("user3"));
+        assertEquals(2, usersAfter.size());
+        assertTrue(usersAfter.contains("user1"));
+        assertTrue(usersAfter.contains("user2"));
+    }
+
+    @Test
+    void removeUser_successfullyRemovesUserAfterSaveAndReopen() throws Exception {
+        Credential newUser = new Credential("user3", "password3".toCharArray());
+        manager.addUser(newUser, dualEntry.getUser1());
+        manager.save();
+
+        reopen();
+
+        Set<String> usersBefore = manager.listUsers();
+        assertTrue(usersBefore.contains("user3"));
+
+        manager.removeUser(dualEntry, "user3");
+        manager.save();
+
+        reopen();
+
+        Set<String> usersAfter = manager.listUsers();
+        assertFalse(usersAfter.contains("user3"));
+        assertEquals(2, usersAfter.size());
+    }
+
+    @Test
+    void removeUser_withBadCredentials_throwsException() throws Exception {
+        Credential newUser = new Credential("user3", "password3".toCharArray());
+        manager.addUser(newUser, dualEntry.getUser1());
+
+        DualEntry badDualEntry = new DualEntry("user1", "wrongpassword".toCharArray(),
+                "user2", "password2".toCharArray());
+        assertThrows(GeneralSecurityException.class,
+                () -> manager.removeUser(badDualEntry, "user3"));
+
+        Set<String> users = manager.listUsers();
+        assertTrue(users.contains("user3"));
+    }
+    @Test
+    void removeUser_multipleUsers_removesCorrectOne() throws Exception {
+        Credential user3 = new Credential("user3", "password3".toCharArray());
+        Credential user4 = new Credential("user4", "password4".toCharArray());
+        manager.addUser(user3, dualEntry.getUser1());
+        manager.addUser(user4, dualEntry.getUser1());
+
+        Set<String> usersBefore = manager.listUsers();
+        assertEquals(4, usersBefore.size());
+
+        manager.removeUser(dualEntry, "user3");
+
+        Set<String> usersAfter = manager.listUsers();
+        assertEquals(3, usersAfter.size());
+        assertFalse(usersAfter.contains("user3"));
+        assertTrue(usersAfter.contains("user4"));
+        assertTrue(usersAfter.contains("user1"));
+        assertTrue(usersAfter.contains("user2"));
+    }
+
+    @Test
+    void removeUser_cannotValidateDeletedUser() throws Exception {
+        Credential newUser = new Credential("user3", "password3".toCharArray());
+        manager.addUser(newUser, dualEntry.getUser1());
+
+        assertTrue(manager.validateUser("user3", "password3".toCharArray()));
+
+        manager.removeUser(dualEntry, "user3");
+
+        assertFalse(manager.validateUser("user3", "password3".toCharArray()));
     }
 
 }


### PR DESCRIPTION
**Summary**

This PR introduces a new public API method removeUser(DualEntry dualEntry, String alias) in VaultManager that safely removes a user from the local user vault only when two authenticated users approve the action and the target user exists.

**What changed**

Added public void **removeUser**(DualEntry, String) that:
- Validates dualEntry is provided.
- Calls checkAccess(dualEntry) to ensure both guardians are valid and in different groups.
- Verifies the target alias exists via **getUser**(alias, null).
- Prevents removing either of the currently authenticated users (user1/user2).
- Delegates to the existing private **removeUser**(alias, null) for the actual deletion.
- Wraps unexpected failures in a **GeneralSecurityException** with a descriptive message.
- No changes to existing persistence, key, or passphrase flows.


**Added serveral test cases on VaultManagerTest.java**

for making sure tests are running
* git clone repository

* Edit **security/build.gradle** file and add the following
```
test {
    useJUnitPlatform()
}
```
* Run the following command:

`./gradlew :security:test --tests "net.e6tech.elements.security.vault.VaultManagerTest"
`
