### PR TITLE
Reflection.replicator touchup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
 
-ext.elementsVersion = '2.7.13'
+ext.elementsVersion = '2.7.14'
 ext.junitPlatformLauncherVersion = '1.6.2'
 ext.junitJupiterVersion = '5.6.2'
 ext.snakeyamlVersion = '2.0'
@@ -24,7 +24,7 @@ ext.findbugsVersion = '3.0.2'
 ext.lmaxDisruptorVerion = '3.4.2'
 ext.slf4jVersion = '1.7.36'
 ext.groovyVersion = '3.0.21'
-ext.guavaVerions = '31.1-jre'  // Using 31.1-jre to avoid Android/JRE variant ambiguity
+ext.guavaVerions = '33.0.0-jre'  // Using explicit -jre variant to avoid Android/JRE ambiguity
 ext.scalaVersion = '2.13.10'
 ext.akkaVersion = '2.6.9'
 ext.akkaScalaVersion = '2.13'
@@ -74,6 +74,21 @@ allprojects {
     apply plugin: 'java'
 
     sourceCompatibility = 1.8
+
+    // Fix for Guava JRE vs Android ambiguity in Gradle 6.x
+    configurations.all {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'com.google.guava' && details.requested.name == 'guava') {
+                details.because('Enforce JRE variant to avoid Android/JRE ambiguity')
+                details.useTarget("${details.requested.group}:${details.requested.name}:${guavaVerions}")
+            }
+        }
+
+        // Additional attribute configuration for Gradle 6.x
+        attributes {
+            attribute(Attribute.of('org.gradle.jvm.environment', String), 'standard-jvm')
+        }
+    }
 
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:syntax', '-quiet')
@@ -202,5 +217,9 @@ subprojects {
 
     tasks.withType(Sign) {
         onlyIf { isReleaseVersion && project.hasProperty("signing.keyId") }
+    }
+
+    test {
+        useJUnitPlatform()
     }
 }

--- a/common/src/main/java/net/e6tech/elements/common/reflection/Reflection.java
+++ b/common/src/main/java/net/e6tech/elements/common/reflection/Reflection.java
@@ -720,10 +720,23 @@ public class Reflection {
                                 if (!handled) {
                                     Object value = prop.getReadMethod().invoke(object);
 
-                                    if (!(value instanceof Collection) &&
-                                            setter.getParameterTypes()[0].isAssignableFrom(prop.getReadMethod().getReturnType())) {
+                                    if (value == null) {
                                         setter.invoke(target, value);
+                                    } else if (value.getClass().isPrimitive()
+                                            || value instanceof String
+                                            || value instanceof Number
+                                            || value instanceof Boolean
+                                            || value instanceof Character
+                                            || value.getClass().isEnum()) {
+                                        // For primitive types, wrapper classes, String, and enums, we can safely copy by reference
+                                        if (setter.getParameterTypes()[0].isAssignableFrom(prop.getReadMethod().getReturnType())) {
+                                            setter.invoke(target, value);
+                                        } else {
+                                            Object converted = newInstance(setter.getGenericParameterTypes()[0], value, seen, copyListener);
+                                            setter.invoke(target, converted);
+                                        }
                                     } else {
+                                        // For complex objects, always create a deep copy
                                         try {
                                             Object converted = newInstance(setter.getGenericParameterTypes()[0], value, seen, copyListener);
                                             setter.invoke(target, converted);

--- a/common/src/test/java/net/e6tech/elements/common/reflection/ReflectionTest.java
+++ b/common/src/test/java/net/e6tech/elements/common/reflection/ReflectionTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Created by futeh.
@@ -65,6 +66,103 @@ public class ReflectionTest {
         Z1 z = Reflection.newInstance(Z1.class, x);
         assertTrue(z.getTypes().get(0) == Z1.Type.a);
     }
+
+    @Test
+    public void copyComplexObject(){
+        int id = 1;
+        String name = "foo";
+
+        ComplexObject complexObject = new ComplexObject(id, name);
+        ComplexObject target = new ComplexObject();
+
+        Reflection.copyInstance(target,complexObject);
+
+        String updateName = "bar";
+
+        assertEquals(target.getId(), id);
+        assertTrue(target.getName().equals(name));
+        assertTrue(target.getSimpleObject() != null);
+        assertEquals(target.getSimpleObject().getId(), id);
+
+        target.setName(updateName);
+        target.getSimpleObject().setName(updateName);
+
+        // original object should not be updated
+        assertTrue(complexObject.getName().equals(name));
+        assertTrue(complexObject.getSimpleObject().getName().equals(name));
+        assertTrue(target.getName().equals(updateName));
+        assertTrue(target.getSimpleObject().getName().equals(updateName));
+    }
+
+    public static class SimpleObject{
+
+        SimpleObject(){}
+
+        SimpleObject(int id, String name){
+            this.id = id;
+            this.name = name;
+        }
+
+        private int id;
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    public static class ComplexObject{
+
+        ComplexObject(){}
+
+        ComplexObject(int id, String name){
+            this.id = id;
+            this.name = name;
+            this.simpleObject = new SimpleObject(id, name);
+
+        }
+
+        private int id;
+        private String name;
+        private SimpleObject simpleObject;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public SimpleObject getSimpleObject() {
+            return simpleObject;
+        }
+
+        public void setSimpleObject(SimpleObject simpleObject) {
+            this.simpleObject = simpleObject;
+        }
+    }
+
 
     public static class X {
         enum Type {


### PR DESCRIPTION

### Context

While debugging https://episodesix.atlassian.net/browse/H3-46259 ( [related e6tech fix PR](https://bitbucket.org/episodesix/e6tech/pull-requests/5040) ) found that `Reflection.copyInstance`, when copying properties, checks if the setter's parameter type is assignable from the property's return type:

```
if (!(value instanceof Collection) &&
        setter.getParameterTypes()[0].isAssignableFrom(prop.getReadMethod().getReturnType())) {
    setter.invoke(target, value);
} else {
    // ... creates new instance
}
```

The issue is that when the inner object is being copied, the condition `setter.getParameterTypes()[0].isAssignableFrom(prop.getReadMethod().getReturnType())` evaluates to `true` because both are of same type. This causes the code to directly assign the reference instead of creating a deep copy.

The fix ensures that:
- null values are handled correctly
- Primitive types, wrapper classes, Strings, and enums are copied by reference
- Complex objects are always deep-copied by calling newInstance, which creates a new instance instead of just copying the reference.

### Changes

- Bumped `elementsVersion` to 2.7.14 and `guavaVersion` to 33.0.0-jre.  ( Futeh mentioned had to be done due to CVE )
- Added Gradle configurations to enforce JRE variant and resolve ambiguity for guava.
- Enhanced `Reflection.copyInstance` to handle primitive types, strings, and enums with deep copy support.  